### PR TITLE
Add account registration workflow example

### DIFF
--- a/DIFF_20250620233707.md
+++ b/DIFF_20250620233707.md
@@ -1,0 +1,74 @@
+diff --git a/examples/workflows/README.md b/examples/workflows/README.md
+new file mode 100644
+index 0000000..f958c10
+--- /dev/null
++++ b/examples/workflows/README.md
+@@ -0,0 +1,16 @@
++# Automated API Registration Workflow
++
++This example demonstrates how to use **browser-use** to sign up for an account on a website, verify the registration through an email inbox, and generate an API key. The workflow relies on environment variables to provide the target URLs and email credentials.
++
++## Environment Variables
++- `SITE_SIGNUP_URL` – URL of the site's sign-up page.
++- `API_SETTINGS_URL` – URL where a new API key can be generated after account verification.
++- `REG_EMAIL` – Email address used for registration.
++- `REG_EMAIL_PASSWORD` – Password for the email account (required if using IMAP to retrieve the verification link).
++
++Ensure you comply with each website's terms of service before automating registrations.
++
++Run the example with:
++```bash
++python auto_api_registration.py
++```
+diff --git a/examples/workflows/auto_api_registration.py b/examples/workflows/auto_api_registration.py
+new file mode 100644
+index 0000000..6d22a13
+--- /dev/null
++++ b/examples/workflows/auto_api_registration.py
+@@ -0,0 +1,46 @@
++import asyncio
++import json
++import os
++
++from dotenv import load_dotenv
++from langchain_openai import ChatOpenAI
++
++from browser_use import Agent, Browser
++
++load_dotenv()
++
++SITE_SIGNUP_URL = os.getenv("SITE_SIGNUP_URL", "https://example.com/signup")
++API_SETTINGS_URL = os.getenv("API_SETTINGS_URL", "https://example.com/settings/api")
++EMAIL_ADDRESS = os.getenv("REG_EMAIL", "user@example.com")
++EMAIL_PASSWORD = os.getenv("REG_EMAIL_PASSWORD", "password")
++
++TASK = f"""
++1. Navigate to {SITE_SIGNUP_URL}.
++2. Register a new account with email {EMAIL_ADDRESS} and a secure password of your choice.
++3. Check the inbox for {EMAIL_ADDRESS} using IMAP and open the verification link in the message.
++4. Once verified, visit {API_SETTINGS_URL} and create a new API key.
++5. Save the generated API key locally using Python.
++"""
++
++browser = Browser()
++agent = Agent(task=TASK, llm=ChatOpenAI(model='gpt-4o'), browser=browser)
++
++async def main():
++    history = await agent.run(max_steps=50)
++    api_key = agent.browser.ctx.shared_state.get("api_key")
++    if api_key:
++        keys_path = os.path.join(os.path.dirname(__file__), "api_keys.json")
++        try:
++            with open(keys_path, "r") as f:
++                data = json.load(f)
++        except FileNotFoundError:
++            data = {}
++        domain = SITE_SIGNUP_URL.split('/')[2]
++        data[domain] = api_key
++        with open(keys_path, "w") as f:
++            json.dump(data, f, indent=2)
++    await browser.close()
++
++if __name__ == '__main__':
++    asyncio.run(main())
++

--- a/RECOMMENDATIONS_20250620233707.md
+++ b/RECOMMENDATIONS_20250620233707.md
@@ -1,0 +1,3 @@
+- Consider adding comprehensive error handling in the workflow example to manage network timeouts and login failures.
+- Provide a helper module for common email verification tasks to reduce duplication across scripts.
+- Integrate rate limiting controls to avoid automated signups violating site policies.

--- a/examples/workflows/README.md
+++ b/examples/workflows/README.md
@@ -1,0 +1,16 @@
+# Automated API Registration Workflow
+
+This example demonstrates how to use **browser-use** to sign up for an account on a website, verify the registration through an email inbox, and generate an API key. The workflow relies on environment variables to provide the target URLs and email credentials.
+
+## Environment Variables
+- `SITE_SIGNUP_URL` – URL of the site's sign-up page.
+- `API_SETTINGS_URL` – URL where a new API key can be generated after account verification.
+- `REG_EMAIL` – Email address used for registration.
+- `REG_EMAIL_PASSWORD` – Password for the email account (required if using IMAP to retrieve the verification link).
+
+Ensure you comply with each website's terms of service before automating registrations.
+
+Run the example with:
+```bash
+python auto_api_registration.py
+```

--- a/examples/workflows/auto_api_registration.py
+++ b/examples/workflows/auto_api_registration.py
@@ -1,0 +1,46 @@
+import asyncio
+import json
+import os
+
+from dotenv import load_dotenv
+from langchain_openai import ChatOpenAI
+
+from browser_use import Agent, Browser
+
+load_dotenv()
+
+SITE_SIGNUP_URL = os.getenv("SITE_SIGNUP_URL", "https://example.com/signup")
+API_SETTINGS_URL = os.getenv("API_SETTINGS_URL", "https://example.com/settings/api")
+EMAIL_ADDRESS = os.getenv("REG_EMAIL", "user@example.com")
+EMAIL_PASSWORD = os.getenv("REG_EMAIL_PASSWORD", "password")
+
+TASK = f"""
+1. Navigate to {SITE_SIGNUP_URL}.
+2. Register a new account with email {EMAIL_ADDRESS} and a secure password of your choice.
+3. Check the inbox for {EMAIL_ADDRESS} using IMAP and open the verification link in the message.
+4. Once verified, visit {API_SETTINGS_URL} and create a new API key.
+5. Save the generated API key locally using Python.
+"""
+
+browser = Browser()
+agent = Agent(task=TASK, llm=ChatOpenAI(model='gpt-4o'), browser=browser)
+
+async def main():
+    history = await agent.run(max_steps=50)
+    api_key = agent.browser.ctx.shared_state.get("api_key")
+    if api_key:
+        keys_path = os.path.join(os.path.dirname(__file__), "api_keys.json")
+        try:
+            with open(keys_path, "r") as f:
+                data = json.load(f)
+        except FileNotFoundError:
+            data = {}
+        domain = SITE_SIGNUP_URL.split('/')[2]
+        data[domain] = api_key
+        with open(keys_path, "w") as f:
+            json.dump(data, f, indent=2)
+    await browser.close()
+
+if __name__ == '__main__':
+    asyncio.run(main())
+


### PR DESCRIPTION
## Summary
- add a workflow example for automatic account registration and API key retrieval
- document environment variables needed for the workflow
- track repo changes in DIFF_20250620233707.md
- add recommendations

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_6855f06413e4832a8b429319f4f6db1f

## Summary by Sourcery

Add a new automated API registration workflow example demonstrating account signup, email verification, and API key generation using browser-use and ChatOpenAI, accompanied by usage documentation, a diff-tracking file, and improvement recommendations.

New Features:
- Provide an automated account registration and API key retrieval workflow example using browser-use and ChatOpenAI

Documentation:
- Document environment variable requirements and usage steps in the workflow README

Chores:
- Add a diff-tracking file
- Add a recommendations file suggesting error handling, helper module extraction, and rate limiting controls

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an automated workflow example for API registration, including account signup, email verification, and API key generation using browser automation.
- **Documentation**
  - Added a README file detailing setup instructions, required environment variables, and usage notes for the new workflow example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->